### PR TITLE
Fix typo in shift notification

### DIFF
--- a/app/Http/Livewire/Shifts.php
+++ b/app/Http/Livewire/Shifts.php
@@ -46,7 +46,7 @@ class Shifts extends Component
         auth()->user()->startShift();
         $this->status = 'On Shift';
         $this->dispatchBrowserEvent('notification', ['type' => 'success', 'message' => 'You are now on shift!']);
-        event(new NotificationSent(new Notification, ['title' => 'Shift Started', 'description' => 'The user started thier shift!']));
+        event(new NotificationSent(new Notification, ['title' => 'Shift Started', 'description' => 'The user started their shift!']));
         $this->emit(self::SHIFT_CHANGED, true);
     }
 
@@ -55,7 +55,7 @@ class Shifts extends Component
         auth()->user()->endShift();
         $this->status = 'Not On Shift';
         $this->dispatchBrowserEvent('notification', ['type' => 'success', 'message' => 'You have ended your shift!']);
-        event(new NotificationSent(new Notification, ['title' => 'Shift Ended', 'description' => 'The user ended thier shift!']));
+        event(new NotificationSent(new Notification, ['title' => 'Shift Ended', 'description' => 'The user ended their shift!']));
         $this->emit(self::SHIFT_CHANGED, false);
     }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [x] 🚩 Other

## Description

This PR fixes a small typo found in the shift notifications; `thier` -> `their`.

## Added to documentation?

- [ ] 📜 readme
- [x] 🙅 no documentation needed
